### PR TITLE
feat: adding RENOVATE_IGNORE_PR_AUTHOR

### DIFF
--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -36,4 +36,5 @@ jobs:
           RENOVATE_AUTODISCOVER_FILTER: "['GlueOps/*']" 
           RENOVATE_REQUIRE_CONFIG: "ignored"
           RENOVATE_FORCE: '{"force": {"schedule": ["at any time"]},"prConcurrentLimit": 0,"prHourlyLimit": 0,"extends": ["github>GlueOps/renovatebot-configs//defaults#v0.0.2"]}'
+          RENOVATE_IGNORE_PR_AUTHOR: "true"
           


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Added the `RENOVATE_IGNORE_PR_AUTHOR` environment variable to the Renovate configuration file.
- This change sets `RENOVATE_IGNORE_PR_AUTHOR` to "true", which affects how Renovate handles pull requests based on the author.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>renovatebot.yml</strong><dd><code>Add RENOVATE_IGNORE_PR_AUTHOR to Renovate configuration</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/renovatebot.yml

<li>Added <code>RENOVATE_IGNORE_PR_AUTHOR</code> environment variable.<br> <li> Set <code>RENOVATE_IGNORE_PR_AUTHOR</code> to "true".<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/renovatebot/pull/5/files#diff-beca849a612a3771ca62f01da1ce5d9aca7479731df16f95cf997c467da1efef">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information