### PR TITLE
fix: just disable renovatebot for a moment

### DIFF
--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -1,10 +1,10 @@
 # https://github.com/renovatebot/github-action?tab=readme-ov-file#example-with-github-app
 name: Renovate
 on:
-  schedule:
-    # The "*" (#42, asterisk) character has special semantics in YAML, so this
-    # string has to be quoted.
-    - cron: '0/15 * * * *'
+  # schedule:
+  #   # The "*" (#42, asterisk) character has special semantics in YAML, so this
+  #   # string has to be quoted.
+  #   - cron: '0/15 * * * *'
   workflow_dispatch:
 jobs:
   renovate:


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Temporarily disable Renovatebot scheduled runs

- Comment out cron schedule trigger


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Renovatebot Workflow"] -- "comment out" --> B["Scheduled Trigger Disabled"]
  C["Manual Trigger"] -- "remains active" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>renovatebot.yml</strong><dd><code>Disable scheduled Renovatebot execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/renovatebot.yml

<ul><li>Comment out the scheduled cron trigger<br> <li> Keep workflow_dispatch trigger active<br> <li> Preserve original cron configuration in comments</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/renovatebot/pull/41/files#diff-beca849a612a3771ca62f01da1ce5d9aca7479731df16f95cf997c467da1efef">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

