### PR TITLE
fix: use latest tag

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -37,5 +37,5 @@ jobs:
           RENOVATE_AUTODISCOVER_FILTER: "['${{ github.repository_owner }}/*']" 
           RENOVATE_AUTODISCOVER_TOPICS: "['allow-auto-merge']"
           RENOVATE_REQUIRE_CONFIG: "ignored"
-          RENOVATE_FORCE: '{"force": {"schedule": ["at any time"]},"prConcurrentLimit": 0,"prHourlyLimit": 0,"extends": ["github>GlueOps/renovatebot-configs//base#v0.0.11","github>GlueOps/renovatebot-configs//auto-merge#v0.0.11"]}'
+          RENOVATE_FORCE: '{"force": {"schedule": ["at any time"]},"prConcurrentLimit": 0,"prHourlyLimit": 0,"extends": ["github>GlueOps/renovatebot-configs//base#v0.0.12","github>GlueOps/renovatebot-configs//auto-merge#v0.0.12"]}'
           RENOVATE_IGNORE_PR_AUTHOR: "true"

--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -36,7 +36,7 @@ jobs:
           RENOVATE_DRY_RUN: "null"  #set to "full" for dryrun and "null" to apply
           RENOVATE_AUTODISCOVER_FILTER: "['${{ github.repository_owner }}/*']" 
           RENOVATE_REQUIRE_CONFIG: "ignored"
-          RENOVATE_FORCE: '{"force": {"schedule": ["at any time"]},"prConcurrentLimit": 0,"prHourlyLimit": 0,"extends": ["github>GlueOps/renovatebot-configs//defaults#v0.0.10"]}'
+          RENOVATE_FORCE: '{"force": {"schedule": ["at any time"]},"prConcurrentLimit": 0,"prHourlyLimit": 0,"extends": ["github>GlueOps/renovatebot-configs//defaults#v0.0.12"]}'
           RENOVATE_IGNORE_PR_AUTHOR: "true"
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Update Renovate configuration tags to v0.0.12

- Synchronize version references across workflow files


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["auto-merge.yaml"] --> B["Update tags v0.0.11 → v0.0.12"]
  C["renovatebot.yml"] --> D["Update tags v0.0.10 → v0.0.12"]
  B --> E["Consistent v0.0.12"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auto-merge.yaml</strong><dd><code>Update Renovate config tags to v0.0.12</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/auto-merge.yaml

<ul><li>Update Renovate config tags from v0.0.11 to v0.0.12<br> <li> Affects both base and auto-merge configuration references</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/renovatebot/pull/44/files#diff-3e652740b8893c7206123dee7cdfa9c9c1db3ef0abb914f2cf3c1fab3eb48015">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>renovatebot.yml</strong><dd><code>Update Renovate defaults tag to v0.0.12</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/renovatebot.yml

<ul><li>Update Renovate defaults config tag from v0.0.10 to v0.0.12<br> <li> Synchronizes version with other workflow files</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/renovatebot/pull/44/files#diff-beca849a612a3771ca62f01da1ce5d9aca7479731df16f95cf997c467da1efef">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

